### PR TITLE
Add building mappings JSON for campus locations and aliases

### DIFF
--- a/src/app/services/places/places.service.ts
+++ b/src/app/services/places/places.service.ts
@@ -1,11 +1,30 @@
 import { Injectable } from '@angular/core';
 import { Location } from '../../interfaces/location.interface';
 import data from 'src/assets/concordia-data.json';
+import buildingMappingsData from 'src/assets/building-mappings.json';
 import { selectSelectedCampus, AppState } from '../../store/app';
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { Store } from '@ngrx/store';
 import { MappedinService, BuildingData } from '../mappedin/mappedin.service';
 import { GoogleMapLocation } from 'src/app/interfaces/google-map-location.interface';
+import { MappedInLocation } from 'src/app/interfaces/mappedin-location.interface';
+
+// Building name mappings for common search terms
+interface BuildingMapping {
+  [key: string]: string[];
+}
+
+// Building priority match interface
+interface PriorityBuilding {
+  title: string;
+  address: string;
+  coordinates: {lat: number, lng: number};
+  campusKey: string;
+}
+
+interface PriorityBuildingMapping {
+  [key: string]: PriorityBuilding;
+}
 
 @Injectable({
   providedIn: 'root'
@@ -14,11 +33,67 @@ export class PlacesService {
   private placesService!: google.maps.places.PlacesService;
   private placesServiceReady = new BehaviorSubject<boolean>(false);
   private campusData: any = data;
+  
+  // Mappings loaded from external file
+  private buildingMappings: BuildingMapping = {};
+  private priorityMatches: PriorityBuildingMapping = {};
 
   constructor(
     private readonly store: Store<AppState>,
     private mappedInService: MappedinService
-  ) {}
+  ) {
+    // Load mappings from external JSON file
+    this.loadBuildingMappings();
+    
+    // Generate additional mapping entries based on building abbreviations
+    this.enhanceBuildingMappings();
+  }
+  
+  /**
+   * Loads building mappings from the external JSON file
+   */
+  private loadBuildingMappings(): void {
+    // Load aliases 
+    this.buildingMappings = (buildingMappingsData as any).aliases || {};
+    
+    // Load priority matches
+    this.priorityMatches = (buildingMappingsData as any).priorityMatches || {};
+  }
+  
+  /**
+   * Enhances the building mappings by adding entries based on the building data
+   * This ensures that new buildings added to concordia-data.json are automatically mapped
+   */
+  private enhanceBuildingMappings(): void {
+    // Process both campuses
+    ['sgw', 'loy'].forEach(campusKey => {
+      const buildings = this.campusData[campusKey]?.buildings || [];
+      
+      buildings.forEach((building: any) => {
+        // Add mapping for abbreviation if not already in mappings
+        if (building.abbreviation) {
+          const abbr = building.abbreviation.toLowerCase();
+          if (!this.buildingMappings[abbr]) {
+            this.buildingMappings[abbr] = [building.name];
+          } else if (!this.buildingMappings[abbr].includes(building.name)) {
+            this.buildingMappings[abbr].push(building.name);
+          }
+        }
+        
+        // Add mapping for name words
+        const nameWords = building.name.toLowerCase().split(' ');
+        nameWords.forEach(word => {
+          if (word.length > 2) { // Skip very short words
+            if (!this.buildingMappings[word]) {
+              this.buildingMappings[word] = [building.name];
+            } else if (!this.buildingMappings[word].includes(building.name)) {
+              this.buildingMappings[word].push(building.name);
+            }
+          }
+        });
+      });
+    });
+  }
 
   /**
    * Initializes the PlacesService with a given Google Map instance.
@@ -40,14 +115,286 @@ export class PlacesService {
     return this.placesServiceReady.asObservable();
   }
 
-  public async getPlaceSuggestions(input: string): Promise<Location[]> {
-    const campusKey = await firstValueFrom(this.store.select(selectSelectedCampus));
-    const campusCoordinates = this.campusData[campusKey]?.coordinates;
-    if (!campusCoordinates) {
-      return [];
+  /**
+   * Gets building suggestions that match the search term based on the mapping
+   * @param searchTerm The search term
+   * @param campusKey The current campus key (sgw or loy)
+   * @returns An array of building locations that match the search term
+   */
+  private getBuildingSuggestions(searchTerm: string, campusKey: string): GoogleMapLocation[] {
+    const normalizedSearchTerm = searchTerm.toLowerCase().trim();
+    if (!normalizedSearchTerm) return [];
+    
+    // For different match priorities
+    const matchedBuildingNames = this.findMatchingBuildingNames(normalizedSearchTerm);
+    if (matchedBuildingNames.length === 0) return [];
+    
+    // Create mapping for campus buildings for quick lookup
+    const campusBuildings = this.campusData[campusKey].buildings;
+    const suggestions: GoogleMapLocation[] = [];
+    const addedNames = new Set<string>();
+    
+    // Special processing for abbreviation matches
+    if (normalizedSearchTerm.length <= 3) {
+      this.addExactAbbreviationMatches(normalizedSearchTerm, campusBuildings, suggestions, addedNames);
     }
+    
+    // Process matched building names and convert to location objects
+    this.addBuildingNameMatches(matchedBuildingNames, campusBuildings, suggestions, addedNames);
+    
+    return suggestions;
+  }
+  
+  /**
+   * Finds building names that match the search term using different matching strategies
+   * @param searchTerm The normalized search term
+   * @returns Array of matching building names with priority ordering
+   */
+  private findMatchingBuildingNames(searchTerm: string): string[] {
+    const exactMatches: string[] = [];
+    const startsWithMatches: string[] = [];
+    const containsMatches: string[] = [];
+    const isShortAbbreviation = searchTerm.length <= 3;
+    
+    // Find matches in building mappings with different priorities
+    Object.entries(this.buildingMappings).forEach(([key, buildingNames]) => {
+      if (key === searchTerm) {
+        // Exact match (highest priority)
+        exactMatches.push(...buildingNames);
+      } else if (key.startsWith(searchTerm)) {
+        // Key starts with search term (high priority)
+        startsWithMatches.push(...buildingNames);
+      } else if (!isShortAbbreviation && searchTerm.includes(key) && key.length > 1) {
+        // Search term contains the key (medium priority) - only for longer queries
+        containsMatches.push(...buildingNames);
+      }
+    });
+    
+    // Combine all matches with prioritization - exact matches first
+    return [...new Set([...exactMatches, ...startsWithMatches, ...containsMatches])];
+  }
+  
+  /**
+   * Adds buildings that exactly match the abbreviation
+   */
+  private addExactAbbreviationMatches(
+    searchTerm: string, 
+    buildings: any[], 
+    results: GoogleMapLocation[], 
+    addedNames: Set<string>
+  ): void {
+    // Check for exact abbreviation match
+    const abbreviationMatch = buildings.find(b => 
+      b.abbreviation && b.abbreviation.toLowerCase() === searchTerm
+    );
+    
+    if (abbreviationMatch) {
+      results.push(this.buildingToLocation(abbreviationMatch));
+      addedNames.add(abbreviationMatch.name);
+    }
+  }
+  
+  /**
+   * Adds buildings matching the building names to the results
+   */
+  private addBuildingNameMatches(
+    buildingNames: string[], 
+    buildings: any[], 
+    results: GoogleMapLocation[], 
+    addedNames: Set<string>
+  ): void {
+    for (const name of buildingNames) {
+      const building = buildings.find(b => {
+        const bName = b.name.toLowerCase();
+        const searchName = name.toLowerCase();
+        
+        return bName === searchName || 
+               bName.includes(searchName) || 
+               searchName.includes(bName);
+      });
+      
+      if (building && !addedNames.has(building.name)) {
+        results.push(this.buildingToLocation(building));
+        addedNames.add(building.name);
+      }
+    }
+  }
+  
+  /**
+   * Converts a building object to a GoogleMapLocation
+   */
+  private buildingToLocation(building: any): GoogleMapLocation {
+    return {
+      title: building.name,
+      address: building.address,
+      coordinates: new google.maps.LatLng(building.coordinates),
+      image: building.image,
+      type: 'outdoor'
+    };
+  }
 
+  /**
+   * Get buildings that exactly match the input from concordia-data.json
+   * This is for finding precise matches from the current campus.
+   * 
+   * @param input User's search input
+   * @param campusKey Current campus
+   * @returns The matching building locations
+   */
+  private getExactBuildingMatch(input: string, campusKey: string): GoogleMapLocation[] {
+    const normalizedInput = input.toLowerCase().trim();
+    if (!normalizedInput) return [];
+    
+    const campusBuildings = this.campusData[campusKey].buildings;
+    const results: GoogleMapLocation[] = [];
+    
+    // Check for buildings with matching abbreviation (highest priority)
+    const abbreviationMatches = campusBuildings.filter(b => 
+      b.abbreviation && b.abbreviation.toLowerCase() === normalizedInput
+    );
+    
+    if (abbreviationMatches.length > 0) {
+      return abbreviationMatches.map(building => this.buildingToLocation(building));
+    }
+    
+    // Check for direct alias matches in our mapping
+    if (this.buildingMappings[normalizedInput]) {
+      const buildingNames = this.buildingMappings[normalizedInput];
+      const addedNames = new Set<string>();
+      
+      // Find buildings that match the alias names
+      for (const name of buildingNames) {
+        const building = campusBuildings.find(b => {
+          const bName = b.name.toLowerCase();
+          const searchName = name.toLowerCase();
+          
+          return bName === searchName || 
+                 bName.includes(searchName) || 
+                 searchName.includes(bName);
+        });
+        
+        if (building && !addedNames.has(building.name)) {
+          results.push(this.buildingToLocation(building));
+          addedNames.add(building.name);
+        }
+      }
+    }
+    
+    return results;
+  }
+
+  /**
+   * Hard-coded building lookup for problematic abbreviations
+   * @param input User input
+   * @param campusKey Current campus key
+   * @returns Building location if found, or null
+   */
+  /**
+   * Direct lookup for problematic abbreviations
+   * This forces specific buildings to be returned for certain abbreviations regardless of campus
+   * @param input User's search input
+   * @returns Building location for high-priority matches, or null if not a priority term
+   */
+  private getDirectBuildingMatch(input: string): GoogleMapLocation | null {
+    const normalizedInput = input.toLowerCase().trim();
+    const problematicTerms = (buildingMappingsData as any).problematicTerms || [];
+    
+    // Only process if this is identified as a problematic term
+    if (!problematicTerms.includes(normalizedInput)) {
+      return null;
+    }
+    
+    // Look up the priority match from the external data
+    const priorityMatch = this.priorityMatches[normalizedInput];
+    
+    if (priorityMatch) {
+      // Always return the correct building regardless of current campus
+      return {
+        title: priorityMatch.title,
+        address: priorityMatch.address,
+        coordinates: new google.maps.LatLng(priorityMatch.coordinates),
+        type: 'outdoor'
+      };
+    }
+    
+    return null;
+  }
+
+  /**
+   * Get room matches from MappedIn service
+   * @param searchTerm The normalized search term
+   * @returns List of matching rooms
+   */
+  private getRoomMatches(searchTerm: string): MappedInLocation[] {
+    const normalizeString = (str: string) => str.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
+    let rooms: MappedInLocation[] = [];
+    
+    // Get campus data from MappedIn service
+    const campusData = this.mappedInService.getCampusMapData() || {};
+    
+    // Process each building
+    for (const [key, building] of Object.entries(campusData) as [string, BuildingData][]) {
+      // Add spaces (rooms)
+      const spaces = building.mapData
+        .getByType('space')
+        .filter(space => space.name)
+        .map(space => this.createRoomLocation(building, key, space));
+        
+      // Add points of interest
+      const pois = building.mapData
+        .getByType('point-of-interest')
+        .filter(poi => poi.name)
+        .map(poi => this.createRoomLocation(building, key, poi));
+        
+      // Add all to rooms array
+      rooms = [...rooms, ...spaces, ...pois];
+    }
+    
+    // Filter rooms by search term and limit to top 3
+    return rooms
+      .filter(room => {
+        const roomWithFullName = room as MappedInLocation & { fullName: string, abbreviation: string };
+        return [room.title, roomWithFullName.fullName, roomWithFullName.abbreviation]
+          .some(field => field && normalizeString(field).includes(searchTerm));
+      })
+      .slice(0, 3);
+  }
+  
+  /**
+   * Create a room location object from MappedIn data
+   * Uses a combination of MappedInLocation and GoogleMapLocation interfaces
+   */
+  private createRoomLocation(
+    building: BuildingData, 
+    mapId: string, 
+    space: any
+  ): any {
+    // Using any here since we're combining multiple interfaces with extra properties
+    return {
+      title: building.abbreviation + ' ' + space.name,
+      address: building.address,
+      coordinates: building.coordinates,
+      fullName: building.name + ' ' + space.name,
+      abbreviation: building.abbreviation,
+      indoorMapId: mapId,
+      room: space,
+      type: 'indoor'
+    };
+  }
+  
+  /**
+   * Get Google place suggestions
+   * @param input The original search input
+   * @param campusCoordinates The coordinates of the current campus
+   * @returns List of GoogleMapLocation objects
+   */
+  private async getGoogleSuggestions(
+    input: string, 
+    campusCoordinates: google.maps.LatLng
+  ): Promise<GoogleMapLocation[]> {
     const autocompleteService = new google.maps.places.AutocompleteService();
+    
+    // Get predictions from Google Places API
     const predictions = await new Promise<google.maps.places.AutocompletePrediction[]>(
       (resolve) => {
         autocompleteService.getPlacePredictions(
@@ -55,7 +402,7 @@ export class PlacesService {
             input,
             componentRestrictions: { country: 'CA' },
             locationBias: new google.maps.Circle({
-              center: new google.maps.LatLng(campusCoordinates),
+              center: campusCoordinates,
               radius: 500
             })
           },
@@ -65,66 +412,97 @@ export class PlacesService {
         );
       }
     );
-
-    let rooms = [];
-    // const campusBuildings:BuildingData[]= Object.values(this.mappedInService.getCampusMapData()) || [];
-    // campusBuildings.forEach((building: BuildingData) => {
-    const campusData = this.mappedInService.getCampusMapData() || {};
-    for (const [key, building] of Object.entries(campusData) as [string, BuildingData][]) {
-      rooms = [
-        ...rooms,
-        ...building.mapData
-          .getByType('space')
-          .filter((space) => space.name)
-          .map((space) => ({
-            title: building.abbreviation + ' ' + space.name,
-            address: building.address,
-            coordinates: building.coordinates,
-            fullName: building.name + ' ' + space.name,
-            abbreviation: building.abbreviation,
-            indoorMapId: key,
-            room: space,
-            type: 'indoor'
-          })),
-        ...building.mapData
-          .getByType('point-of-interest')
-          .filter((poi) => poi.name)
-          .map((poi) => ({
-            title: building.abbreviation + ' ' + poi.name,
-            address: building.address,
-            coordinates: building.coordinates,
-            fullName: building.name + ' ' + poi.name,
-            abbreviation: building.abbreviation,
-            indoorMapId: key,
-            room: poi,
-            type: 'indoor'
-          }))
-      ];
+    
+    // Get details for each prediction
+    const detailsPromises = predictions.map(prediction => this.getPlaceDetail(prediction));
+    const details = await Promise.all(detailsPromises);
+    
+    // Filter out null results
+    return details.filter(detail => detail !== null) as GoogleMapLocation[];
+  }
+  
+  /**
+   * Combine building matches from exact and broader search
+   */
+  private combineBuildingMatches(input: string, campusKey: string): GoogleMapLocation[] {
+    const exactMatches = this.getExactBuildingMatch(input, campusKey);
+    const suggestions = this.getBuildingSuggestions(input, campusKey);
+    
+    // Use a Set to track which buildings we've already included
+    const uniqueTitles = new Set(exactMatches.map(b => b.title));
+    const allMatches = [...exactMatches];
+    
+    // Add suggestions that aren't already included
+    for (const building of suggestions) {
+      if (!uniqueTitles.has(building.title)) {
+        allMatches.push(building);
+        uniqueTitles.add(building.title);
+      }
     }
+    
+    return allMatches;
+  }
+
+  /**
+   * Main method to get place suggestions for the input
+   * @param input User's search input
+   * @returns List of location suggestions ordered by priority
+   */
+  public async getPlaceSuggestions(input: string): Promise<Location[]> {
+    // Get current campus information
+    const campusKey = await firstValueFrom(this.store.select(selectSelectedCampus));
+    const campusCoordinates = this.campusData[campusKey]?.coordinates;
+    if (!campusCoordinates) return [];
 
     const normalizeString = (str: string) => str.toLowerCase().replace(/[^a-zA-Z0-9]/g, '');
     const searchTerm = normalizeString(input);
-
-    const selectedBuildingRooms = rooms.filter((room) =>
-      [room.title, room.fullName, room.abbreviation] // Check abbreviation, full name, and short name
-        .some((field) => field && normalizeString(field).includes(searchTerm))
-    );
-
-    const detailsPromises = predictions.map((prediction) => this.getPlaceDetail(prediction));
-    let details = await Promise.all(detailsPromises);
-    details = [...selectedBuildingRooms.slice(0, 3), ...details];
-
-    // Filter out any null values (failed details)
-    return details.filter(
-      (
-        detail
-      ): detail is {
-        title: string;
-        address: string;
-        coordinates: google.maps.LatLng;
-        type: 'outdoor';
-      } => detail !== null
-    );
+    const inputLower = input.toLowerCase().trim();
+    
+    // Step 1: Check for priority matches that need special handling
+    const priorityMatch = this.getDirectBuildingMatch(inputLower);
+    if (priorityMatch) {
+      return [priorityMatch]; // Return ONLY priority match if found
+    }
+    
+    // Step 2: Handle abbreviations specially - buildings only, no rooms or Google
+    if (inputLower.length <= 3) {
+      // Try exact building match first
+      const exactMatches = this.getExactBuildingMatch(inputLower, campusKey);
+      if (exactMatches.length > 0) {
+        return exactMatches;
+      }
+      
+      // Then try broader building suggestions
+      const buildingSuggestions = this.getBuildingSuggestions(inputLower, campusKey);
+      if (buildingSuggestions.length > 0) {
+        return buildingSuggestions;
+      }
+    }
+    
+    // Step 3: For non-abbreviations, combine all types of results
+    // Get building matches with merged duplicates
+    const buildingMatches = this.combineBuildingMatches(inputLower, campusKey);
+    
+    // Get matching rooms
+    const roomMatches = this.getRoomMatches(searchTerm);
+    
+    // Get Google suggestions, but only if:
+    // - Input is not an abbreviation, OR
+    // - We don't have any building or room matches
+    let googleMatches: GoogleMapLocation[] = [];
+    if (inputLower.length > 3 || (buildingMatches.length === 0 && roomMatches.length === 0)) {
+      googleMatches = await this.getGoogleSuggestions(input, campusCoordinates);
+    }
+    
+    // Combine results in priority order:
+    // 1. Building matches
+    // 2. Room matches
+    // 3. Google matches
+    return [
+      ...buildingMatches,
+      ...roomMatches,
+      ...googleMatches
+    ].filter(match => match !== null);
   }
 
   private getPlaceDetail(

--- a/src/app/services/places/places.service.ts
+++ b/src/app/services/places/places.service.ts
@@ -125,6 +125,11 @@ export class PlacesService {
     const normalizedSearchTerm = searchTerm.toLowerCase().trim();
     if (!normalizedSearchTerm) return [];
     
+    // Check if campus data and buildings exist
+    if (!this.campusData || !this.campusData[campusKey] || !this.campusData[campusKey].buildings) {
+      return [];
+    }
+    
     // For different match priorities
     const matchedBuildingNames = this.findMatchingBuildingNames(normalizedSearchTerm);
     if (matchedBuildingNames.length === 0) return [];
@@ -155,6 +160,11 @@ export class PlacesService {
     const startsWithMatches: string[] = [];
     const containsMatches: string[] = [];
     const isShortAbbreviation = searchTerm.length <= 3;
+    
+    // Check if buildingMappings is defined
+    if (!this.buildingMappings) {
+      return [];
+    }
     
     // Find matches in building mappings with different priorities
     Object.entries(this.buildingMappings).forEach(([key, buildingNames]) => {
@@ -245,6 +255,11 @@ export class PlacesService {
     const normalizedInput = input.toLowerCase().trim();
     if (!normalizedInput) return [];
     
+    // Check if campus data and buildings exist
+    if (!this.campusData || !this.campusData[campusKey] || !this.campusData[campusKey].buildings) {
+      return [];
+    }
+    
     const campusBuildings = this.campusData[campusKey].buildings;
     const results: GoogleMapLocation[] = [];
     
@@ -258,7 +273,7 @@ export class PlacesService {
     }
     
     // Check for direct alias matches in our mapping
-    if (this.buildingMappings[normalizedInput]) {
+    if (this.buildingMappings && this.buildingMappings[normalizedInput]) {
       const buildingNames = this.buildingMappings[normalizedInput];
       const addedNames = new Set<string>();
       
@@ -296,11 +311,18 @@ export class PlacesService {
    * @returns Building location for high-priority matches, or null if not a priority term
    */
   private getDirectBuildingMatch(input: string): GoogleMapLocation | null {
+    if (!input) return null;
+    
     const normalizedInput = input.toLowerCase().trim();
     const problematicTerms = (buildingMappingsData as any).problematicTerms || [];
     
     // Only process if this is identified as a problematic term
     if (!problematicTerms.includes(normalizedInput)) {
+      return null;
+    }
+    
+    // Check if priorityMatches is defined
+    if (!this.priorityMatches) {
       return null;
     }
     
@@ -425,6 +447,11 @@ export class PlacesService {
    * Combine building matches from exact and broader search
    */
   private combineBuildingMatches(input: string, campusKey: string): GoogleMapLocation[] {
+    // Check if campus data exists before proceeding
+    if (!this.campusData || !this.campusData[campusKey]) {
+      return [];
+    }
+    
     const exactMatches = this.getExactBuildingMatch(input, campusKey);
     const suggestions = this.getBuildingSuggestions(input, campusKey);
     

--- a/src/assets/building-mappings.json
+++ b/src/assets/building-mappings.json
@@ -1,0 +1,101 @@
+{
+  "aliases": {
+    "cc": ["Central Building"],
+    "h": ["Hall"],
+    "mb": ["John Molson School of Business"],
+    "ev": ["Engineering and Visual Arts"],
+    "lb": ["Webster Library"],
+    "er": ["ER Building"],
+    "sp": ["Richard J. Renaud Science Complex"],
+    "vl": ["Vanier Library"],
+    "ve": ["Vanier Extension"],
+    "cl": ["3 Amigos Building"],
+    
+    "hall": ["Hall"],
+    "hall building": ["Hall"],
+    "central": ["Central Building"],
+    "jmsb": ["John Molson School of Business"],
+    "molson": ["John Molson School of Business"],
+    "business": ["John Molson School of Business"],
+    "business school": ["John Molson School of Business"],
+    "engineering": ["Engineering and Visual Arts"],
+    "visual arts": ["Engineering and Visual Arts"],
+    "library": ["Webster Library", "Vanier Library"],
+    "webster": ["Webster Library"],
+    "science": ["Richard J. Renaud Science Complex"],
+    "science complex": ["Richard J. Renaud Science Complex"],
+    "renaud": ["Richard J. Renaud Science Complex"],
+    "vanier": ["Vanier Library"],
+    "amigos": ["3 Amigos Building"],
+    "3 amigos": ["3 Amigos Building"],
+    
+    "faubourg": ["Faubourg Building"],
+    "fb": ["Faubourg Building"],
+    "gym": ["Engineering and Visual Arts"],
+    "le gym": ["Engineering and Visual Arts"],
+    "annexe": ["Annex Building"],
+    "grey nuns": ["Grey Nuns Building"],
+    "grey nun": ["Grey Nuns Building"],
+    "gn": ["Grey Nuns Building"],
+    "concordia library": ["Webster Library", "Vanier Library"],
+    "admin": ["Administration Building"],
+    "admin building": ["Administration Building"],
+    "ad": ["Administration Building"],
+    "loyola gym": ["Athletics Complex"],
+    "athletics": ["Athletics Complex"],
+    "ic": ["Innovation Center"],
+    "innovation": ["Innovation Center"],
+    "psych building": ["Psychology Building"],
+    "psych": ["Psychology Building"],
+    "ps": ["Psychology Building"],
+    "theology": ["TH Building"],
+    "th": ["TH Building"]
+  },
+  "priorityMatches": {
+    "cc": {
+      "title": "Central Building",
+      "address": "7141 Sherbrooke St W, Montreal, Quebec H4B 1R6",
+      "coordinates": {"lat": 45.45849007178699, "lng": -73.64064018870205},
+      "campusKey": "loy"
+    },
+    "sp": {
+      "title": "Richard J. Renaud Science Complex",
+      "address": "3475 Rue West Broadway, Montréal, QC H4B 2A7",
+      "coordinates": {"lat": 45.45784653344979, "lng": -73.64157117911424},
+      "campusKey": "loy"
+    },
+    "vl": {
+      "title": "Vanier Library",
+      "address": "7141 Sherbrooke St. W. Montreal, Quebec, Canada H4B 1R6",
+      "coordinates": {"lat": 45.45905565, "lng": -73.63840962048661},
+      "campusKey": "loy"
+    },
+    "ve": {
+      "title": "Vanier Extension",
+      "address": "7141 Sherbrooke St. W. Montreal, Quebec, Canada H4B 1R6",
+      "coordinates": {"lat": 45.45905565, "lng": -73.63840962048661},
+      "campusKey": "loy"
+    },
+    "central": {
+      "title": "Central Building",
+      "address": "7141 Sherbrooke St W, Montreal, Quebec H4B 1R6",
+      "coordinates": {"lat": 45.45849007178699, "lng": -73.64064018870205},
+      "campusKey": "loy"
+    },
+    "fb": {
+      "title": "Faubourg Building",
+      "address": "1250 Guy St, Montreal, Quebec H3H 2T4",
+      "coordinates": {"lat": 45.494671, "lng": -73.579167},
+      "campusKey": "sgw"
+    },
+    "gym": {
+      "title": "Engineering and Visual Arts",
+      "address": "1515 Saint-Catherine St W #1428, Montreal, Quebec H3G 1S6",
+      "coordinates": {"lat": 45.49541909930391, "lng": -73.57769260301784},
+      "campusKey": "sgw"
+    }
+  },
+  "problematicTerms": [
+    "cc", "sp", "vl", "ve", "central", "fb", "gym"
+  ]
+}


### PR DESCRIPTION
Summary

- Enhanced search to prioritize Concordia buildings when users search by abbreviation
- Fixed specific abbreviation issues (CC, SP, VL, etc.) where buildings weren't showing first
- Refactored code to separate building data from service logic
- Improved maintainability through better code organization
Problem

When searching for building abbreviations like "CC", "SP", or "VL", users would often get classrooms or Google results
instead of the buildings themselves. This happened because:

- Building might be on a different campus than currently selected
- Google Maps suggestions competing with our buildings
- Room codes matching before building names
- Different capitalization causing inconsistent results
- Solution

Created a dedicated building mapping system that:

- Identifies problematic abbreviations
- Forces correct buildings to appear first in search
- Extends existing autocomplete to handle these special cases
- Maintains building mappings in external JSON for easy updates